### PR TITLE
fix: Correct SysAdmin dynamics

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ _Here is an example of randomly generated adjacency matrix:_
 
 If you used this environment for your experiments or found it helpful, consider citing it:
 <pre>
-@article{sintes2025cognac,
-  title={COGNAC - Cooperative Graph-based Networked Agent Challenges for Multi-Agent Reinforcement Learning},
-  author={Sintes, Jules}, 
+@inproceeding{sintes2025cognac,
+  title={COGNAC: Cooperative Graph-based Networked Agent Challenges for Multi-Agent Reinforcement Learning},
+  author={Sintes, Jules and Busic, Ana},
   url={\url{https://github.com/yojul/cognac}},
-  publisher={Github},
-  year={2025},
+  journal={Advances in Neural Information Processing Systems},
+  year={2025}
 }
 </pre>
 

--- a/cognac/env/BinaryConsensus/env.py
+++ b/cognac/env/BinaryConsensus/env.py
@@ -61,7 +61,7 @@ class BinaryConsensusNetworkEnvironment(ParallelEnv):
             If True, use a shared global reward. If False, compute rewards per agent.
         """
 
-        self.adjacency_matrix = adjacency_matrix
+        self.adjacency_matrix = adjacency_matrix.copy()
         self.n_agents = adjacency_matrix.shape[0]
         self.possible_agents = list(range(self.n_agents))
         self.agents = None

--- a/cognac/env/SysAdmin/env.py
+++ b/cognac/env/SysAdmin/env.py
@@ -125,7 +125,7 @@ class SysAdminNetworkEnvironment(ParallelEnv):
         faulty_success_rate: float = 0.1,
     ):
         # Env properties
-        self.adjacency_matrix = adjacency_matrix
+        self.adjacency_matrix = adjacency_matrix.copy()
         self.n_agents = adjacency_matrix.shape[0]
         self.possible_agents = list(range(self.n_agents))
         self.agents = None
@@ -144,7 +144,7 @@ class SysAdminNetworkEnvironment(ParallelEnv):
         self.base_dead_rate = self.dead_rate_multiplier * self.base_fail_rate
 
         # Probability of influencing action in [0,1]
-        self.adjacency_matrix_prob = self.adjacency_matrix
+        self.adjacency_matrix_prob = self.adjacency_matrix.copy()
         self._check_adjacency_matrix()
         # Add self influence w/ base fail rate paramater
         np.fill_diagonal(self.adjacency_matrix_prob, self.base_fail_rate)
@@ -177,6 +177,7 @@ class SysAdminNetworkEnvironment(ParallelEnv):
             If any of the validation checks fail.
         """
         # Check that the diagonal is zero
+        print(self.adjacency_matrix_prob)
         assert all(
             [self.adjacency_matrix_prob[i, i] == 0 for i in range(self.n_agents)]
         )

--- a/cognac/env/SysAdmin/env.py
+++ b/cognac/env/SysAdmin/env.py
@@ -118,11 +118,11 @@ class SysAdminNetworkEnvironment(ParallelEnv):
         show_neighborhood_state: bool = False,
         reward_class: BaseReward = SysAdminDefaultReward,
         is_global_reward: bool = False,
-        base_arrival_rate: float = 0.5,
-        base_fail_rate: float = 0.1,
-        dead_rate_multiplier: float = 0.2,
+        base_arrival_rate: float = 0.2,
+        base_fail_rate: float = 0.15,
+        dead_rate_multiplier: float = 0.05,
         base_success_rate: float = 0.3,
-        faulty_success_rate: float = 0.1,
+        faulty_success_rate: float = 0.2,
     ):
         # Env properties
         self.adjacency_matrix = adjacency_matrix.copy()

--- a/cognac/env/SysAdmin/env.py
+++ b/cognac/env/SysAdmin/env.py
@@ -177,7 +177,6 @@ class SysAdminNetworkEnvironment(ParallelEnv):
             If any of the validation checks fail.
         """
         # Check that the diagonal is zero
-        print(self.adjacency_matrix_prob)
         assert all(
             [self.adjacency_matrix_prob[i, i] == 0 for i in range(self.n_agents)]
         )


### PR DESCRIPTION
This corrects two major issues:

-  Computers were never entering dead state because it was setting state to 1 (instead of incrementing +1)
- The propagation mechanisms was not implemented correctly regarding the formal description of the problem. Now it considers independent propagation of faulty or dead state from each neighbors according to edge weights from adjacency matrix.
- We still allow a computer to go from working to dead in a single step with a small probability due to the order of computation for updates.

Thanks to @tommasomarzi for catching this bug.